### PR TITLE
Improved matching of multi-word "cussWords"

### DIFF
--- a/bc-ProfanityBlock.js
+++ b/bc-ProfanityBlock.js
@@ -458,10 +458,10 @@ class ContentFilterBadWord {
       // Remove spaces between letters only for bad words
       cussWords.forEach((cussWord) => {
         // Create a dynamic regular expression that matches the bad word with any spaces between the letters
-        let wordRegex = new RegExp(cussWord.split("").join("\\s*"), "gi");
+        let wordRegex = new RegExp((cussWord.replace(/\s+/g, '')).split("").join("\\s*"), "gi");
         // Replace the matched substring with the bad word without spaces
         normalizedText = normalizedText.replace(wordRegex, (match) => {
-          return match.replace(/\s/g, "");
+          return match.replace(/\s/g, "").replace(cussWord.replace(/\s+/g, ''), cussWord);
         });
       });
     }


### PR DESCRIPTION
Entries in the cussWords array which contained spaces were not matched when detectEvasionCharacters was set to true. By first running the cussword through a regex to remove spaces, and then replacing the de-spaced match in a string with the version from the cussword array, those entries are now correctly detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of multi-word profanity, including phrases with internal spaces or characters inserted between letters.
  * Replacements now preserve the original phrase formatting, preventing awkward spacing or collapsed text in blocked content.
  * Delivers more consistent and robust moderation across edge cases without changing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->